### PR TITLE
Update location of haproxy-ingress

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -30,4 +30,4 @@ dependencies:
 - name: haproxy-ingress
   version: 0.0.26
   alias: haproxy
-  repository: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  repository: "https://charts.helm.sh/incubator"


### PR DESCRIPTION
@bartversluijs Thank you for all your great work on this repo! 

I just ran the install script from your comment [here](https://forums.balena.io/t/kubernetes-for-scaling/132102/39) and it appears the haproxy-ingress install location has been moved. Wanted to update for future users!

This commit resolves error: 
```
...Unable to get an update from the "https://kubernetes-charts-incubator.storage.googleapis.com" chart repository:
	failed to fetch https://kubernetes-charts-incubator.storage.googleapis.com/index.yaml : 403 Forbidden
```
When running the install script `./scripts/k8s install` in this repo.