### PR TITLE
Registry: Deployment without PV

### DIFF
--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openbalena
 description: openBalena kubernetes Chart
 type: application
-version: 1.0.2
+version: 1.1.0
 appVersion: v3.4.1
 keywords:
 - balena

--- a/kubernetes/helm/templates/deployments/registry.yaml
+++ b/kubernetes/helm/templates/deployments/registry.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "openbalena.fullname" . }}-registry
   namespace: {{ .Release.Namespace }}
@@ -19,7 +19,6 @@ spec:
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  serviceName: {{ include "openbalena.fullname" . }}-registry
   selector:
     matchLabels:
       {{- include "openbalena.selectorLabels" . | nindent 6 }}
@@ -116,8 +115,7 @@ spec:
           name: cgroup
       volumes:
       - name: data
-        persistentVolumeClaim:
-          claimName: data
+        emptyDir: {}
       - name: run
         emptyDir:
           medium: Memory
@@ -129,14 +127,3 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  volumeClaimTemplates:
-  - metadata:
-      name: data
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      {{- if .Values.registry.storageClass }}
-      storageClassName: {{ .Values.registry.storageClass }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.registry.storage }}

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -165,9 +165,6 @@ registry:
     annotations: {}
     externalIPs: []
 
-  storage: "10Gi"
-  storageClass:
-
 # openBalena S3
 s3:
   # If disabled, please provide details in .config.s3


### PR DESCRIPTION
The Registry is stateless and doesn't need a persistent volume, because the data is automatically stored in an S3 storage.

Because of this, the registry isn't a statefulset any longer, but a deployment without a persistent volume for the data.