### PR TITLE
Helm: HAProxy Ingress 0.13.6

### DIFF
--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 
 dependencies:
 - name: haproxy-ingress
-  version: 0.13.4
+  version: 0.13.6
   alias: haproxy
   repository: "https://haproxy-ingress.github.io/charts"
 

--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openbalena
 description: openBalena kubernetes Chart
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: v3.4.3
 keywords:
 - balena

--- a/kubernetes/helm/README.md
+++ b/kubernetes/helm/README.md
@@ -5,7 +5,7 @@
 This openBalena - Helm Chart is an unofficial Kubernetes chart, but will allow you to run openBalena in a Kubernetes cluster.  
 
 # Dependencies
-- [HAProxy Ingress v0.13.4](https://github.com/jcmoraisjr/haproxy-ingress)
+- [HAProxy Ingress v0.13.6](https://github.com/jcmoraisjr/haproxy-ingress)
 
 # Installing the chart
 First, you've to generate a new configuration of openBalena using the `quickstart`. This will generate the `docker-compose` values as well as a `kubernetes.yaml` file, which contains everything from the config but in the Chart format. Example of running the quickstart below.

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -237,7 +237,7 @@ redis:
 ##
 ## HAProxy Ingress Chart
 ##
-## https://github.com/haproxy-ingress/charts/blob/master/haproxy-ingress/values.yaml
+## https://github.com/haproxy-ingress/charts/blob/0.13.6/haproxy-ingress/values.yaml
 ##
 haproxy:
   controller:


### PR DESCRIPTION
Upgraded HAProxy Ingress to 0.13.6.
Main reason is the [IngressClassResource option](https://github.com/haproxy-ingress/charts/blob/0.13.6/haproxy-ingress/values.yaml#L71-L75).

To enable this, add the following to the `config/kubernetes.yaml` file:
```yaml
haproxy:
  controller:
    ingressClassResource:
      enabled: true
```

_For more options, please [see haproxy-ingress/values.yaml](https://github.com/haproxy-ingress/charts/blob/0.13.6/haproxy-ingress/values.yaml)_