### PR TITLE
Helm: enable IngressClass resource by default

### DIFF
--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openbalena
 description: openBalena kubernetes Chart
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: v3.6.0
 keywords:
 - balena

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -257,7 +257,11 @@ redis:
 ##
 haproxy:
   controller:
+    # Set the IngressClass name and enable the IngressClass resource
+    # Using a custom ingress class name enables the openBalena instance to use a scoped Ingress instance, this will prevent issues with the custom config as set below.
     ingressClass: "openbalena-haproxy"
+    ingressClassResource:
+      enabled: true
 
     # Change config of HAProxy
     # This will add a snippet for the VPN using port 443


### PR DESCRIPTION
This enables the IngressClass resource by default, which will fix issues when using the IngressClass name `openbalena-haproxy`, for instance when using `cert-manager`.