### PR TITLE
Helm: HAProxy Ingress 0.13.7

### DIFF
--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 
 dependencies:
 - name: haproxy-ingress
-  version: 0.13.6
+  version: 0.13.7
   alias: haproxy
   repository: "https://haproxy-ingress.github.io/charts"
 

--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openbalena
 description: openBalena kubernetes Chart
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: v3.6.0
 keywords:
 - balena

--- a/kubernetes/helm/README.md
+++ b/kubernetes/helm/README.md
@@ -5,7 +5,7 @@
 This openBalena - Helm Chart is an unofficial Kubernetes chart, but will allow you to run openBalena in a Kubernetes cluster.  
 
 # Dependencies
-- [HAProxy Ingress v0.13.6](https://github.com/jcmoraisjr/haproxy-ingress)
+- [HAProxy Ingress v0.13.7](https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.13.7)
 
 # Installing the chart
 First, you've to generate a new configuration of openBalena using the `quickstart`. This will generate the `docker-compose` values as well as a `kubernetes.yaml` file, which contains everything from the config but in the Chart format. Example of running the quickstart below.


### PR DESCRIPTION
Updated HAProxy Ingress to 0.13.7 [(see changelog)](https://github.com/jcmoraisjr/haproxy-ingress/blob/master/CHANGELOG/CHANGELOG-v0.13.md#v0137).

**Please note**
Before updating, execute the following command:
```bash
helm dependency update ./kubernetes/helm
```

This will update the dependencies of Helm first.