### PR TITLE
Remove domain root from TLS hosts

### DIFF
--- a/kubernetes/helm/templates/ingress/http.yaml
+++ b/kubernetes/helm/templates/ingress/http.yaml
@@ -21,7 +21,6 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.global.hostname }}
     - api.{{ .Values.global.hostname }}
     - registry.{{ .Values.global.hostname }}
 


### PR DESCRIPTION
As far as I know, the root hostname is not used by openbalena, and there is no requirement to have a DNS record set for it.

Prior to this change, my cert renewal was failing as my openbalena root domain is pointing to a public website for my project.